### PR TITLE
Apple now uses the same naming convetion across all repositories

### DIFF
--- a/rpm-from-source.sh
+++ b/rpm-from-source.sh
@@ -26,7 +26,7 @@ wget https://github.com/apple/swift-llvm/archive/swift-${TAG}.tar.gz -O llvm.tar
 mv llvm.tar.gz $RPMTOPDIR/SOURCES/
 wget https://github.com/apple/swift-llbuild/archive/swift-${TAG}.tar.gz -O llbuild.tar.gz
 mv llbuild.tar.gz $RPMTOPDIR/SOURCES/
-wget https://github.com/apple/swift-cmark/archive/0.22.0.tar.gz -O cmark.tar.gz
+wget https://github.com/apple/swift-cmark/archive/swift-${TAG}.tar.gz -O cmark.tar.gz
 mv cmark.tar.gz $RPMTOPDIR/SOURCES/
 
 sed -e "s/%{ver}/$VER/" -e "s/%{rel}/$REL/" -e "s/%{tag}/$TAG/" swift.spec > $RPMTOPDIR/SPECS/swift.spec

--- a/swift.spec
+++ b/swift.spec
@@ -36,7 +36,7 @@ gzip -dc ../SOURCES/package-manager.tar.gz | tar -xvvf -
 mv swift-swift-%{tag} swift
 mv swift-integration-tests-swift-%{tag} swift-integration-tests
 mv swift-clang-swift-%{tag} clang
-mv swift-cmark-0.22.0 cmark
+mv swift-cmark-swift-%{tag} cmark
 mv swift-corelibs-foundation-swift-%{tag} swift-corelibs-foundation
 mv swift-corelibs-xctest-swift-%{tag} swift-corelibs-xctest
 mv swift-llbuild-swift-%{tag} llbuild


### PR DESCRIPTION
Pretty straightforward fix
