### PR TITLE
Changes to make the script work with Swift 4 codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # swift-rpm
-Swift RPM for Fedora.
+Swift RPM for Fedora. - Updated to Swift 4.0
 
 ## Install Swift RPM
 ```bash
 sudo dnf install libbsd python gcc-c++ clang
-sudo rpm -Uvh swift-2.2-SNAPSHOT20151210a.x86_64.rpm
+sudo rpm -Uvh swift-4.0-RELEASE4.0.x86_64.rpm
 ```
-Tested on Fedora 22 and 23, 64 bits.
+Tested on Fedora 26, 64-bit.
 
 ## Run a RPM build
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # swift-rpm
-Swift RPM for Fedora. - Updated to Swift 4.0
+Swift RPM for Fedora. - Updated to Swift 4.0.2
 
 ## Install Swift RPM
 ```bash
 sudo dnf install libbsd python gcc-c++ clang
 
-sudo rpm -Uvh swift-4.0-RELEASE4.0.x86_64.rpm
+sudo rpm -Uvh swift-4.0.2-RELEASE4.0.2.x86_64.rpm
 ```
 Tested on Fedora 26, 64-bit.
 

--- a/rpm-from-source.sh
+++ b/rpm-from-source.sh
@@ -5,7 +5,7 @@ sudo ln -s /usr/bin/ninja-build /usr/bin/ninja
 # We need to manually get and deal with the blocks runtime
 # TODO: Add check for whether files are already there
 pushd /tmp
-git clone git://github.com/tachoknight/blocksruntime
+git clone https://github.com/mackyle/blocksruntime
 cd /tmp/blocksruntime
 ./buildlib
 ./checktests
@@ -17,9 +17,9 @@ popd
 RPMTOPDIR=~/rpmbuild
 mkdir -p $RPMTOPDIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
-TAG=4.0-RELEASE
-VER=4.0
-REL=RELEASE4.0
+TAG=4.0.2-RELEASE
+VER=4.0.2
+REL=RELEASE4.0.2
 
 
 wget https://github.com/apple/swift/archive/swift-${TAG}.tar.gz -O swift.tar.gz

--- a/rpm-from-source.sh
+++ b/rpm-from-source.sh
@@ -1,12 +1,24 @@
 echo on 
-sudo dnf install -y rpm-build ninja-build clang libicu-devel gcc-c++ cmake libuuid-devel libedit-devel swig pkgconfig libbsd-devel libxml2-devel libsqlite3x-devel python-devel autoconf automake libtool libcurl-devel
+sudo dnf install -y rpm-build ninja-build clang libicu-devel gcc-c++ cmake libuuid-devel libedit-devel swig pkgconfig libbsd-devel libxml2-devel libsqlite3x-devel python-devel autoconf automake libtool libcurl-devel libatomic
 sudo ln -s /usr/bin/ninja-build /usr/bin/ninja
+
+# We need to manually get and deal with the blocks runtime
+# TODO: Add check for whether files are already there
+pushd /tmp
+git clone git://github.com/tachoknight/blocksruntime
+cd /tmp/blocksruntime
+./buildlib
+./checktests
+sudo ./installlib
+sudo ln -s /usr/local/lib/libBlocksRuntime.a /usr/lib/libBlocksRuntime.a
+sudo ln -s /usr/local/include/Block.h /usr/include/Block.h
+popd
 
 RPMTOPDIR=~/rpmbuild
 mkdir -p $RPMTOPDIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-TAG=3.1-RELEASE
-VER=3.1
-REL=RELEASE3.1
+TAG=4.0-RELEASE
+VER=4.0
+REL=RELEASE4.0
 
 wget https://github.com/apple/swift/archive/swift-${TAG}.tar.gz -O swift.tar.gz
 mv swift.tar.gz $RPMTOPDIR/SOURCES/swift.tar.gz

--- a/rpm-from-source.sh
+++ b/rpm-from-source.sh
@@ -4,9 +4,9 @@ sudo ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 RPMTOPDIR=~/rpmbuild
 mkdir -p $RPMTOPDIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-TAG=3.0-RELEASE
-VER=3.0
-REL=RELEASE3.0
+TAG=3.1-RELEASE
+VER=3.1
+REL=RELEASE3.1
 
 wget https://github.com/apple/swift/archive/swift-${TAG}.tar.gz -O swift.tar.gz
 mv swift.tar.gz $RPMTOPDIR/SOURCES/swift.tar.gz

--- a/swift.spec
+++ b/swift.spec
@@ -77,9 +77,29 @@ sed -i.bak "s/^validation-test/#validation-test/g" ./utils/build-presets.ini
 # in subsequent versions
 sed -i '/#include <vector>/a #include <functional>' ../lldb/include/lldb/Utility/TaskPool.h
 
+# Under Fedora 27, xlocale.h is no longer available, per:
+# https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27
+sed -i 's/#include <xlocale.h>/\/\/#include <xlocale.h>/' ./stdlib/public/stubs/Stubs.cpp
+sed -i 's/#include <xlocale.h>/\/\/#include <xlocale.h>/' ./stdlib/public/SDK/os/os_trace_blob.c
+sed -i 's/#include <xlocale.h>/\/\/#include <xlocale.h>/' ../swift-corelibs-foundation/CoreFoundation/Base.subproj/CFInternal.h
+sed -i 's/#include <xlocale.h>/\/\/#include <xlocale.h>/' ../swift-corelibs-foundation/CoreFoundation/String.subproj/CFStringDefaultEncoding.h
+sed -i 's/#include <xlocale.h>/\/\/#include <xlocale.h>/' ../swift-corelibs-foundation/CoreFoundation/String.subproj/CFStringEncodings.c
+
+
+# Under Fedora 27, SIGUNUSED (31) has been removed, so going to use SIGSYS, which
+# was defined previously as the same (31) and has the comment "Bad System Call"
+sed -i 's/SIGUNUSED/SIGSYS/' ../llbuild/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+sed -i 's/SIGUNUSED/SIGSYS/' ../llbuild/lib/Commands/NinjaBuildCommand.cpp
+sed -i 's/SIGUNUSED/SIGSYS/' ../swiftpm/Sources/Basic/Process.swift
+
+#
+# We're finished with our modifications, so now we're going to actually build Swift, et al.
+#
+
 # This is the line that actually does the build. Grab a coffee or tea because this is going
 # to take awhile
 ./utils/build-script --preset=buildbot_linux install_destdir=%{buildroot} installable_package=%{buildroot}/swift-%{ver}-%{rel}-fedora26.tar.gz
+
 # Moving the tar file out of the way in case we want to examine it
 cp %{buildroot}/swift-%{ver}-%{rel}-fedora26.tar.gz ~
 rm %{buildroot}/swift-%{ver}-%{rel}-fedora26.tar.gz

--- a/swift.spec
+++ b/swift.spec
@@ -9,6 +9,8 @@ Source0: swift.tar.gz
 Source1: clang.tar.gz
 Source2: cmark.tar.gz
 Source3: corelibs-foundation.tar.gz
+# Explicitly commented out here as we get it from
+# git below
 #Source4: corelibs-libdispatch.tar.gz
 Source4: corelibs-xctest.tar.gz
 Source5: llbuild.tar.gz
@@ -45,10 +47,27 @@ mv swift-llbuild-swift-%{tag} llbuild
 mv swift-lldb-swift-%{tag} lldb
 mv swift-llvm-swift-%{tag} llvm
 mv swift-package-manager-swift-%{tag} swiftpm
+# Explicit checkout of ninja which we need to do, apparently
+# starting with 3.1
+git clone https://github.com/ninja-build/ninja.git ../BUILD/ninja
+pushd ../BUILD/ninja
+git checkout release
+popd
+
+# XYZZY - test for me
+pushd ../BUILD
+rm -rf swift
+git clone git@github.com:tachoknight/swift.git swift
+pushd swift
+git checkout xyzzy-swift-3.1-RELEASE
+popd
+popd
+
 # Explicit checkout of libdispatch so we can also initialize
 # the submodules
 git clone https://github.com/apple/swift-corelibs-libdispatch swift-corelibs-libdispatch
 pushd swift-corelibs-libdispatch
+git checkout swift-3.1-branch
 git submodule init; git submodule update
 popd
 
@@ -63,10 +82,10 @@ cd swift
 # at the end.
 sed -i.bak "s/^test/#test/g" ./utils/build-presets.ini
 sed -i.bak "s/^validation-test/#validation-test/g" ./utils/build-presets.ini
-./utils/build-script --preset=buildbot_linux install_destdir=%{buildroot} installable_package=%{buildroot}/swift-%{ver}-%{rel}-fedora24.tar.gz
+./utils/build-script --preset=buildbot_linux install_destdir=%{buildroot} installable_package=%{buildroot}/swift-%{ver}-%{rel}-fedora25.tar.gz
 # Moving the tar file out of the way
-cp %{buildroot}/swift-%{ver}-%{rel}-fedora24.tar.gz ~
-rm %{buildroot}/swift-%{ver}-%{rel}-fedora24.tar.gz
+cp %{buildroot}/swift-%{ver}-%{rel}-fedora25.tar.gz ~
+rm %{buildroot}/swift-%{ver}-%{rel}-fedora25.tar.gz
 
 %files
 %defattr(-, root, root)

--- a/swift.spec
+++ b/swift.spec
@@ -57,7 +57,7 @@ popd
 # XYZZY - test for me
 pushd ../BUILD
 rm -rf swift
-git clone git@github.com:tachoknight/swift.git swift
+git clone https://github.com/tachoknight/swift swift
 pushd swift
 git checkout xyzzy-swift-3.1-RELEASE
 popd

--- a/swift.spec
+++ b/swift.spec
@@ -49,12 +49,6 @@ mv swift-llbuild-swift-%{tag} llbuild
 mv swift-lldb-swift-%{tag} lldb
 mv swift-llvm-swift-%{tag} llvm
 mv swift-package-manager-swift-%{tag} swiftpm
-# Explicit checkout of ninja which we need to do, apparently
-# starting with 3.1
-git clone https://github.com/ninja-build/ninja.git ../BUILD/ninja
-pushd ../BUILD/ninja
-git checkout release
-popd
 
 
 # Explicit checkout of libdispatch so we can also initialize


### PR DESCRIPTION
The changes in this pull request will successfully build a Swift 3.1 RPM. It requires explicitly getting Ninja from GitHub, and it also uses my forked version of the Swift 3.1 codebase because there was a change necessary in the util/build script to set C compiler flags that do not seem to be set correctly in Fedora.